### PR TITLE
Enable streaming in chat client

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -294,60 +294,55 @@ function sendMessage() {
     // Show clear chat button after the first message is sent
     document.getElementById("new-chat-button").style.display = "block";
 
-    fetch("/send", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ message: message, user_name: userName }),
-    })
-    .then(response => {
-        if (!response.ok) {
-            return response.json().then(data => {
-                displayError(data);
-                return Promise.reject(data);
-            });
+    const streamUrl = `/send_stream?message=${encodeURIComponent(message)}&user_name=${encodeURIComponent(userName)}`;
+    const evtSource = new EventSource(streamUrl);
+    let aiContent = "";
+
+    evtSource.onmessage = function(event) {
+        if (event.data === "[DONE]") {
+            evtSource.close();
+            return;
         }
-        return response.json();
-    })
-    .then(data => {
-        console.log(data.status);
-        chatBox.removeChild(typingDiv);
-        if (voiceChatEnabled && data.audio_url) {
-            // Add audio control element
-            createAudioElement(data.audio_url, chatBox);
-        } else {
-            updateChat(data.conversation);
-        }
-        
-        // Display Patreon promotion if one was returned, but as a modal instead of in the chat
-        if (data.patreon_promo) {
-            // Check if we have the showPatreonModal function (newer popup implementation)
-            if (typeof showPatreonModal === 'function') {
-                showPatreonModal(data.patreon_promo);
-            } else {
-                // Fallback to old method for compatibility
-                const promoDiv = document.createElement('div');
-                promoDiv.innerHTML = data.patreon_promo;
-                chatBox.appendChild(promoDiv);
-                chatBox.scrollTop = chatBox.scrollHeight;
+
+        const data = JSON.parse(event.data);
+        if (data.type === "start") {
+            typingDiv.textContent = characterName + ": ";
+        } else if (data.type === "content") {
+            aiContent += data.content;
+            typingDiv.innerHTML = characterName + ": " + aiContent.replace(/\n/g, "<br>");
+            chatBox.scrollTop = chatBox.scrollHeight;
+        } else if (data.type === "complete") {
+            evtSource.close();
+            if (voiceChatEnabled && data.audio_url) {
+                createAudioElement(data.audio_url, chatBox);
             }
+            if (data.patreon_promo) {
+                if (typeof showPatreonModal === 'function') {
+                    showPatreonModal(data.patreon_promo);
+                } else {
+                    const promoDiv = document.createElement('div');
+                    promoDiv.innerHTML = data.patreon_promo;
+                    chatBox.appendChild(promoDiv);
+                }
+            }
+            if (data.current_persona) {
+                activePersona = data.current_persona;
+            }
+            chatBox.scrollTop = chatBox.scrollHeight;
+        } else if (data.type === "error") {
+            evtSource.close();
+            chatBox.removeChild(typingDiv);
+            displayError(data);
         }
-        
-        // Check if the server included the current persona in response
-        if (data.current_persona) {
-            activePersona = data.current_persona;
+    };
+
+    evtSource.onerror = function(err) {
+        console.error("Stream error:", err);
+        evtSource.close();
+        if (chatBox.contains(typingDiv)) {
+            chatBox.removeChild(typingDiv);
         }
-    })
-    .catch(error => {
-        console.error("Error:", error);
-        chatBox.removeChild(typingDiv);
-        // If error already displayed via displayError, skip fallback
-        if (error.patreon_url || error.message) return;
-        let errorDiv = document.createElement("div");
-        errorDiv.className = "ai-message";
-        errorDiv.textContent = activePersona + ": Oops, something went wrong!";
-        chatBox.appendChild(errorDiv);
-        chatBox.scrollTop = chatBox.scrollHeight;
-    });
+    };
 
     input.value = "";
 }


### PR DESCRIPTION
## Summary
- switch client chat requests from `/send` to `/send_stream`
- handle streaming server-sent events in `static/script.js`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683fa2bd1f3c832aa4f53b9c27ec8ac4