### PR TITLE
Fix SSE generator context

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, render_template, request, jsonify, session, send_file, url_for, Response, redirect, flash, send_from_directory
+from flask import Flask, render_template, request, jsonify, session, send_file, url_for, Response, redirect, flash, send_from_directory, stream_with_context
 import openai_tts_test  # Import the TTS script
 from openai import OpenAI
 import os
@@ -784,7 +784,7 @@ def send_message_stream():
             yield "data: [DONE]\n\n"
 
     return Response(
-        generate_stream(),
+        stream_with_context(generate_stream()),
         mimetype='text/event-stream',
         headers={
             'Cache-Control': 'no-cache',
@@ -1061,7 +1061,7 @@ def get_first_message_stream():
             yield "data: [DONE]\n\n"
 
     return Response(
-        generate_stream(),
+        stream_with_context(generate_stream()),
         mimetype='text/event-stream',
         headers={
             'Cache-Control': 'no-cache',


### PR DESCRIPTION
## Summary
- ensure streaming SSE generators have Flask request context by using `stream_with_context`

## Testing
- `python -m py_compile app.py openai_tts_test.py patreon_popup.py personas.py usage_reports.py mommy_llama.py`

------
https://chatgpt.com/codex/tasks/task_e_683fb122f4ac832aa51d87b68bf99eed