### PR TITLE
Fix disciplinarian dashboard

### DIFF
--- a/disciplinarian_site/app.py
+++ b/disciplinarian_site/app.py
@@ -10,37 +10,64 @@ app = Flask(__name__)
 app.secret_key = os.getenv("DISCIPLINE_SECRET", "discipline-secret-key")
 
 # Initialize Fireworks AI client
-fireworks_client = OpenAI(
-    api_key=os.getenv("FIREWORKS_API_KEY"),
-    base_url="https://api.fireworks.ai/inference/v1"
-)
+fireworks_api_key = os.getenv("FIREWORKS_API_KEY")
+if fireworks_api_key:
+    fireworks_client = OpenAI(
+        api_key=fireworks_api_key,
+        base_url="https://api.fireworks.ai/inference/v1"
+    )
+else:
+    fireworks_client = None
 
 # Initialize Firebase
-cred = credentials.Certificate("spanking-chat-firebase-adminsdk-fbsvc-e7307d7abb.json")
-if not firebase_admin._apps:
-    firebase_admin.initialize_app(cred)
-
-db = firestore.client()
+firebase_credentials = os.getenv("FIREBASE_CREDENTIALS", "spanking-chat-firebase-adminsdk-fbsvc-e7307d7abb.json")
+if os.path.exists(firebase_credentials):
+    cred = credentials.Certificate(firebase_credentials)
+    if not firebase_admin._apps:
+        firebase_admin.initialize_app(cred)
+    db = firestore.client()
+else:
+    db = None  # Fall back to in-memory store when credentials are missing
+    in_memory_db = {
+        'discipline_users': {},
+        'discipline_profiles': {}
+    }
 
 # ----- Helper functions -----
 def register_user(email, password):
-    user_ref = db.collection('discipline_users').document(email)
-    if user_ref.get().exists:
-        return False, "Email already registered"
-    hashed = pbkdf2_sha256.hash(password)
-    user_ref.set({
-        'email': email,
-        'password': hashed,
-        'created_at': firestore.SERVER_TIMESTAMP
-    })
+    """Register a new user either in Firestore or the in-memory store."""
+    if db:
+        user_ref = db.collection('discipline_users').document(email)
+        if user_ref.get().exists:
+            return False, "Email already registered"
+        hashed = pbkdf2_sha256.hash(password)
+        user_ref.set({
+            'email': email,
+            'password': hashed,
+            'created_at': firestore.SERVER_TIMESTAMP
+        })
+    else:
+        if email in in_memory_db['discipline_users']:
+            return False, "Email already registered"
+        hashed = pbkdf2_sha256.hash(password)
+        in_memory_db['discipline_users'][email] = {
+            'email': email,
+            'password': hashed
+        }
     return True, "Registration successful"
 
 def login_user(email, password):
-    user_ref = db.collection('discipline_users').document(email)
-    doc = user_ref.get()
-    if not doc.exists:
-        return False, "User not found"
-    data = doc.to_dict()
+    """Validate user credentials."""
+    if db:
+        user_ref = db.collection('discipline_users').document(email)
+        doc = user_ref.get()
+        if not doc.exists:
+            return False, "User not found"
+        data = doc.to_dict()
+    else:
+        data = in_memory_db['discipline_users'].get(email)
+        if not data:
+            return False, "User not found"
     if pbkdf2_sha256.verify(password, data['password']):
         session['user_email'] = email
         return True, "Login successful"
@@ -73,15 +100,19 @@ def signup():
         success, message = register_user(email, password)
         if success:
             session['user_email'] = email
-            # Save disciplinarian info
-            db.collection('discipline_profiles').document(email).set({
+            profile = {
                 'user_name': session.get('user_name'),
                 'user_gender': session.get('user_gender'),
                 'disciplinarian': session.get('disciplinarian'),
                 'rules': [],
                 'punishments': [],
-                'history': []
-            })
+                'history': [],
+                'todos': []
+            }
+            if db:
+                db.collection('discipline_profiles').document(email).set(profile)
+            else:
+                in_memory_db['discipline_profiles'][email] = profile
             return redirect(url_for('dashboard'))
         flash(message)
     return render_template('signup.html')
@@ -103,6 +134,86 @@ def dashboard():
         return redirect(url_for('login'))
     return render_template('dashboard.html')
 
+# ----- Data Endpoints -----
+def _get_profile(email):
+    if db:
+        doc = db.collection('discipline_profiles').document(email).get()
+        return doc.to_dict() if doc.exists else {}
+    return in_memory_db['discipline_profiles'].get(email, {})
+
+def _update_profile(email, fields):
+    if db:
+        db.collection('discipline_profiles').document(email).update(fields)
+    else:
+        in_memory_db['discipline_profiles'][email].update(fields)
+
+@app.route('/data/history')
+def get_history():
+    if 'user_email' not in session:
+        return jsonify([]), 401
+    profile = _get_profile(session['user_email'])
+    return jsonify(profile.get('history', []))
+
+@app.route('/data/rules')
+def get_rules():
+    if 'user_email' not in session:
+        return jsonify([]), 401
+    profile = _get_profile(session['user_email'])
+    return jsonify(profile.get('rules', []))
+
+@app.route('/data/rules', methods=['POST'])
+def add_rule():
+    if 'user_email' not in session:
+        return jsonify({'error': 'Unauthorized'}), 401
+    rule = request.json.get('rule')
+    if not rule:
+        return jsonify({'error': 'No rule provided'}), 400
+    profile = _get_profile(session['user_email'])
+    rules = profile.get('rules', [])
+    rules.append(rule)
+    _update_profile(session['user_email'], {'rules': rules})
+    return jsonify({'status': 'ok'})
+
+@app.route('/data/punishments')
+def get_punishments():
+    if 'user_email' not in session:
+        return jsonify([]), 401
+    profile = _get_profile(session['user_email'])
+    return jsonify(profile.get('punishments', []))
+
+@app.route('/data/punishments', methods=['POST'])
+def add_punishment():
+    if 'user_email' not in session:
+        return jsonify({'error': 'Unauthorized'}), 401
+    punishment = request.json.get('punishment')
+    if not punishment:
+        return jsonify({'error': 'No punishment provided'}), 400
+    profile = _get_profile(session['user_email'])
+    punishments = profile.get('punishments', [])
+    punishments.append({'text': punishment, 'completed': False})
+    _update_profile(session['user_email'], {'punishments': punishments})
+    return jsonify({'status': 'ok'})
+
+@app.route('/data/todos')
+def get_todos():
+    if 'user_email' not in session:
+        return jsonify([]), 401
+    profile = _get_profile(session['user_email'])
+    return jsonify(profile.get('todos', []))
+
+@app.route('/data/todos', methods=['POST'])
+def add_todo():
+    if 'user_email' not in session:
+        return jsonify({'error': 'Unauthorized'}), 401
+    item = request.json.get('item')
+    if not item:
+        return jsonify({'error': 'No item provided'}), 400
+    profile = _get_profile(session['user_email'])
+    todos = profile.get('todos', [])
+    todos.append({'text': item, 'completed': False})
+    _update_profile(session['user_email'], {'todos': todos})
+    return jsonify({'status': 'ok'})
+
 # Chat endpoint using Fireworks DeepSeek model
 @app.route('/chat', methods=['POST'])
 def chat():
@@ -110,8 +221,13 @@ def chat():
         return jsonify({'error': 'Unauthorized'}), 401
     message = request.json.get('message')
     email = session['user_email']
-    profile_ref = db.collection('discipline_profiles').document(email)
-    profile = profile_ref.get().to_dict()
+    if db:
+        profile_ref = db.collection('discipline_profiles').document(email)
+        profile_doc = profile_ref.get()
+        profile = profile_doc.to_dict() if profile_doc.exists else {}
+    else:
+        profile_ref = None
+        profile = in_memory_db['discipline_profiles'].get(email, {})
     conversation = profile.get('history', [])
 
     system_prompt = generate_system_prompt(profile['disciplinarian'])
@@ -119,14 +235,20 @@ def chat():
         conversation.append({'role': 'system', 'content': system_prompt})
     conversation.append({'role': 'user', 'content': message})
 
-    response = fireworks_client.chat.completions.create(
-        model="deepseek-v3-0324",
-        messages=conversation
-    )
-    reply = response.choices[0].message.content
+    if fireworks_client:
+        response = fireworks_client.chat.completions.create(
+            model="deepseek-v3-0324",
+            messages=conversation
+        )
+        reply = response.choices[0].message.content
+    else:
+        reply = f"(AI response placeholder) {message}"  # Fallback when no API key
     conversation.append({'role': 'assistant', 'content': reply})
 
-    profile_ref.update({'history': conversation})
+    if db and profile_ref:
+        profile_ref.update({'history': conversation})
+    else:
+        in_memory_db['discipline_profiles'][email]['history'] = conversation
     return jsonify({'reply': reply})
 
 # Utility to build system prompt from disciplinarian config
@@ -136,7 +258,8 @@ def generate_system_prompt(config):
         f"You are {config['name']}, a {config['age']}-year-old {config['gender']} disciplinarian. "
         f"Your personality is {config['personality']} and your strictness level is {config['strictness']}. "
         f"You believe in punishments such as: {punishments}. "
-        "Your goal is to discipline and support the user with firm but caring guidance."
+        "Your goal is to discipline and support the user with firm but caring guidance. "
+        "If the user breaks established rules you must assign an appropriate punishment from the list."
     )
     return prompt
 

--- a/disciplinarian_site/static/style.css
+++ b/disciplinarian_site/static/style.css
@@ -1,2 +1,4 @@
 body { font-family: Arial, sans-serif; margin: 40px; }
 h1 { color: #333; }
+nav button { margin-right: 8px; }
+.section { margin-top: 20px; }

--- a/disciplinarian_site/templates/dashboard.html
+++ b/disciplinarian_site/templates/dashboard.html
@@ -5,8 +5,18 @@
     <title>Disciplinarian Dashboard</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     <script>
+        function showSection(id) {
+            document.querySelectorAll('.section').forEach(sec => sec.style.display = 'none');
+            document.getElementById(id).style.display = 'block';
+            if(id === 'history') loadHistory();
+            if(id === 'rules') loadRules();
+            if(id === 'punishments') loadPunishments();
+            if(id === 'todo') loadTodos();
+        }
+
         async function sendMessage() {
             const message = document.getElementById('user-input').value;
+            if(!message) return;
             const res = await fetch('/chat', {
                 method: 'POST',
                 headers: {'Content-Type': 'application/json'},
@@ -17,12 +27,60 @@
             chatBox.value += '\nYou: ' + message + '\nAI: ' + data.reply;
             document.getElementById('user-input').value = '';
         }
+
+        async function loadHistory(){
+            const res = await fetch('/data/history');
+            const history = await res.json();
+            const list = document.getElementById('history-list');
+            list.innerHTML = '';
+            history.forEach(h => { if(h.role==='user'||h.role==='assistant'){ const li = document.createElement('li'); li.textContent = h.role+': '+h.content; list.appendChild(li);} });
+        }
+        async function loadRules(){
+            const res = await fetch('/data/rules');
+            const rules = await res.json();
+            const list = document.getElementById('rules-list');
+            list.innerHTML = '';
+            rules.forEach(r => { const li = document.createElement('li'); li.textContent = r; list.appendChild(li); });
+        }
+        async function loadPunishments(){
+            const res = await fetch('/data/punishments');
+            const items = await res.json();
+            const list = document.getElementById('punishments-list');
+            list.innerHTML = '';
+            items.forEach(p => { const li = document.createElement('li'); li.textContent = p.text + (p.completed ? ' (done)' : ''); list.appendChild(li); });
+        }
+        async function loadTodos(){
+            const res = await fetch('/data/todos');
+            const items = await res.json();
+            const list = document.getElementById('todo-list');
+            list.innerHTML = '';
+            items.forEach(t => { const li = document.createElement('li'); li.textContent = t.text + (t.completed ? ' (done)' : ''); list.appendChild(li); });
+        }
     </script>
 </head>
 <body>
     <h1>Welcome, {{ session.user_name }}</h1>
-    <textarea id="chat-box" rows="10" cols="80" readonly></textarea><br>
-    <input type="text" id="user-input">
-    <button onclick="sendMessage()">Send</button>
+    <nav>
+        <button onclick="showSection('chat')">Chat</button>
+        <button onclick="showSection('history')">History</button>
+        <button onclick="showSection('rules')">Rules</button>
+        <button onclick="showSection('punishments')">Punishments</button>
+        <button onclick="showSection('todo')">To-Do</button>
+    </nav>
+    <div id="chat" class="section">
+        {% include 'chat_section.html' %}
+    </div>
+    <div id="history" class="section" style="display:none">
+        {% include 'history_section.html' %}
+    </div>
+    <div id="rules" class="section" style="display:none">
+        {% include 'rules_section.html' %}
+    </div>
+    <div id="punishments" class="section" style="display:none">
+        {% include 'punishments_section.html' %}
+    </div>
+    <div id="todo" class="section" style="display:none">
+        {% include 'todo_section.html' %}
+    </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add fallback when API keys or firebase credentials missing
- expose data endpoints and store in memory if firebase unavailable
- show dashboard sections for chat, history, rules, punishments and todo list
- tweak styling

## Testing
- `python -m py_compile disciplinarian_site/app.py`
- `python disciplinarian_site/app.py` *(server started successfully)*

------
https://chatgpt.com/codex/tasks/task_e_68407b34a648832aa35feabf47fe7146