### PR TITLE
Enable auto voice recording loop

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -60,7 +60,7 @@ function createAudioElement(audioUrl, container) {
     let audioDiv = document.createElement("div");
     audioDiv.className = "ai-message";
     let audioControl = document.createElement("audio");
-    audioControl.controls = true;
+    audioControl.controls = false;       // hide controls
     audioControl.autoplay = true;
     audioControl.src = audioUrl;
     
@@ -71,6 +71,12 @@ function createAudioElement(audioUrl, container) {
         audioControl.muted = false;
         audioControl.play().catch(e => console.log("Autoplay prevented by browser:", e));
     }, 100);
+    // Start a new recording when playback completes
+    audioControl.addEventListener("ended", () => {
+        if (window.autoRecordAfterResponse) {
+            window.autoRecordAfterResponse();
+        }
+    });
     
     audioDiv.appendChild(audioControl);
     container.appendChild(audioDiv);

--- a/templates/voice_chat.html
+++ b/templates/voice_chat.html
@@ -267,6 +267,10 @@
                     recordingText.textContent = 'Transcribing...';
                 }
             }
+            // Expose recording controls globally
+            window.startRecording = startRecording;
+            window.stopRecording = stopRecording;
+            window.autoRecordAfterResponse = () => startRecording();
             
             function transcribeAudio(audioBlob) {
                 const formData = new FormData();


### PR DESCRIPTION
## Summary
- expose start/stopRecording globally in voice_chat
- auto start recording after each AI audio response

## Testing
- `pytest -q` *(fails: ProxyError while trying to fetch external ElevenLabs API)*

------
https://chatgpt.com/codex/tasks/task_e_68490889c8b8832aab20e75edc729035