### PR TITLE
Enable auto voice recording loop

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -60,7 +60,7 @@ function createAudioElement(audioUrl, container) {
     let audioDiv = document.createElement("div");
     audioDiv.className = "ai-message";
     let audioControl = document.createElement("audio");
-    audioControl.controls = true;
+    audioControl.controls = false;       // hide controls
     audioControl.autoplay = true;
     audioControl.src = audioUrl;
     
@@ -71,6 +71,12 @@ function createAudioElement(audioUrl, container) {
         audioControl.muted = false;
         audioControl.play().catch(e => console.log("Autoplay prevented by browser:", e));
     }, 100);
+    // Start a new recording when playback completes
+    audioControl.addEventListener("ended", () => {
+        if (window.autoRecordAfterResponse) {
+            window.autoRecordAfterResponse();
+        }
+    });
     
     audioDiv.appendChild(audioControl);
     container.appendChild(audioDiv);

--- a/templates/voice_chat.html
+++ b/templates/voice_chat.html
@@ -203,6 +203,11 @@
             let audioChunks = [];
             let recordingTimer;
             let recordingSeconds = 0;
+            let audioContext;
+            let analyser;
+            let silenceStart = null;
+            const SILENCE_THRESHOLD = 0.02; // normalized amplitude
+            const MAX_SILENCE = 1500; // ms of silence before auto-stop
             const voiceButton = document.getElementById('voice-input-btn');
             const recordingStatus = document.getElementById('recording-status');
             const recordingText = document.getElementById('recording-text');
@@ -224,6 +229,39 @@
                     .then(stream => {
                         mediaRecorder = new MediaRecorder(stream);
                         audioChunks = [];
+
+                        const AC = window.AudioContext || window.webkitAudioContext;
+                        audioContext = new AC();
+                        analyser = audioContext.createAnalyser();
+                        const source = audioContext.createMediaStreamSource(stream);
+                        source.connect(analyser);
+                        analyser.fftSize = 2048;
+                        const dataArray = new Uint8Array(analyser.fftSize);
+
+                        const monitorSilence = () => {
+                            analyser.getByteTimeDomainData(dataArray);
+                            let max = 0;
+                            for (let i = 0; i < dataArray.length; i++) {
+                                max = Math.max(max, Math.abs(dataArray[i] - 128));
+                            }
+                            const amplitude = max / 128;
+                            if (amplitude < SILENCE_THRESHOLD) {
+                                if (!silenceStart) {
+                                    silenceStart = Date.now();
+                                } else if (Date.now() - silenceStart > MAX_SILENCE) {
+                                    stopRecording();
+                                    return;
+                                }
+                            } else {
+                                silenceStart = null;
+                            }
+
+                            if (mediaRecorder && mediaRecorder.state === 'recording') {
+                                requestAnimationFrame(monitorSilence);
+                            }
+                        };
+
+                        requestAnimationFrame(monitorSilence);
                         
                         mediaRecorder.ondataavailable = event => {
                             audioChunks.push(event.data);
@@ -238,7 +276,7 @@
                         mediaRecorder.start();
                         voiceButton.classList.add('recording');
                         recordingStatus.classList.add('active');
-                        recordingText.textContent = 'Recording... Click the mic to stop';
+                        recordingText.textContent = 'Recording... speak now';
                         
                         // Start the timer
                         recordingSeconds = 0;
@@ -254,19 +292,31 @@
             function stopRecording() {
                 if (mediaRecorder && mediaRecorder.state !== 'inactive') {
                     mediaRecorder.stop();
-                    
+
                     // Stop all audio tracks to release the microphone
                     mediaRecorder.stream.getTracks().forEach(track => track.stop());
-                    
+
                     // Clear the timer
                     clearInterval(recordingTimer);
-                    
+
+                    if (audioContext) {
+                        audioContext.close();
+                        audioContext = null;
+                        analyser = null;
+                    }
+
+                    silenceStart = null;
+
                     // Update UI
                     voiceButton.classList.remove('recording');
                     recordingStatus.classList.remove('active');
                     recordingText.textContent = 'Transcribing...';
                 }
             }
+            // Expose recording controls globally
+            window.startRecording = startRecording;
+            window.stopRecording = stopRecording;
+            window.autoRecordAfterResponse = () => startRecording();
             
             function transcribeAudio(audioBlob) {
                 const formData = new FormData();


### PR DESCRIPTION
## Summary
- expose start/stopRecording globally in voice_chat
- auto start recording after each AI audio response
- automatically stop voice recording when silence is detected

## Testing
- `pytest -q` *(fails: ProxyError while trying to fetch external ElevenLabs API)*

------
https://chatgpt.com/codex/tasks/task_e_68490889c8b8832aab20e75edc729035